### PR TITLE
Make sure a command it's not a dependency of itself

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Vitor Enes <vitorenesduarte@gmail.com>"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-threshold = "0.6.2"
+threshold = "0.6.3"
 rand = "0.7"
 permutator = "0.3"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,12 +2,16 @@ use planet_sim::client::Workload;
 use planet_sim::config::Config;
 use planet_sim::metrics::Stats;
 use planet_sim::planet::{Planet, Region};
-use planet_sim::protocol::{Atlas, EPaxos, Process};
+use planet_sim::protocol::{Atlas, EPaxos, Newt, Process};
 use std::thread;
 
 const STACK_SIZE: usize = 64 * 1024 * 1024; // 64mb
 
 fn main() {
+    // println!(">running newt n = 5 | f = 1...");
+    // let config = Config::new(5, 1);
+    // run_in_thread(move || increasing_load::<Newt>(config));
+
     println!(">running atlas n = 5 | f = 1...");
     let mut config = Config::new(5, 1);
     config.set_transitive_conflicts(true);
@@ -75,7 +79,7 @@ fn increasing_load<P: Process>(config: Config) {
     ];
 
     // number of clients
-    let cs = vec![8, 16, 32, 64, 128, 256, 512, 1024, 2048];
+    let cs = vec![8, 16, 32, 64, 128, 256];
 
     // clients workload
     let conflict_rate = 10;
@@ -179,7 +183,7 @@ fn run<P: Process>(
         client_regions,
         planet,
     );
-    println!("outcome: {:?}", latencies);
+    println!("simulation ended...");
 
     // compute stats
     let (issued_commands, mean_sum, p5_sum, p95_sum, p99_sum, p999_sum) = latencies

--- a/src/protocol/atlas.rs
+++ b/src/protocol/atlas.rs
@@ -111,7 +111,8 @@ impl Atlas {
 
         // compute its clock
         // - here we shouldn't save the command in `keys_clocks`; if we do, it will be declared as a
-        //   dependency of itself when this message is handled by its own coordinator
+        //   dependency of itself when this message is handled by its own coordinator, which
+        //   prevents fast paths with f > 1
         // TODO is there a parallel with newt? or it doesn't suffer from this problem?
         let clock = self.keys_clocks.clock(&cmd);
 

--- a/src/protocol/common/dependency/clocks/quorum.rs
+++ b/src/protocol/common/dependency/clocks/quorum.rs
@@ -4,6 +4,7 @@ use threshold::{MaxSet, TClock, VClock};
 
 type ThresholdClock = TClock<ProcessId, MaxSet>;
 
+#[derive(Debug)]
 pub struct QuorumClocks {
     // fast quorum size
     q: usize,

--- a/src/protocol/epaxos.rs
+++ b/src/protocol/epaxos.rs
@@ -118,7 +118,7 @@ impl EPaxos {
         // compute its clock
         // - similarly to Atlas, here we shouldn't save the command in `keys_clocks`; if we do, it
         //   will be declared as a dependency of itself when this message is handled by its own
-        //   coordinator
+        //   coordinator, which prevents fast paths with f > 1
         let clock = self.keys_clocks.clock(&cmd);
 
         // create `MCollect` and target

--- a/src/protocol/epaxos.rs
+++ b/src/protocol/epaxos.rs
@@ -116,8 +116,10 @@ impl EPaxos {
         let cmd = Some(cmd);
 
         // compute its clock
+        // - similarly to Atlas, here we shouldn't save the command in `keys_clocks`; if we do, it
+        //   will be declared as a dependency of itself when this message is handled by its own
+        //   coordinator
         let clock = self.keys_clocks.clock(&cmd);
-        self.keys_clocks.add(dot, &cmd);
 
         // create `MCollect` and target
         let mcollect = Message::MCollect {
@@ -161,8 +163,14 @@ impl EPaxos {
             return None;
         }
 
-        // compute its clock
-        let clock = self.keys_clocks.clock_with_past(&cmd, remote_clock);
+        // optimization: compute clock if not from self
+        let clock = if from == self.bp.process_id {
+            remote_clock
+        } else {
+            self.keys_clocks.clock_with_past(&cmd, remote_clock)
+        };
+
+        // save command in order to be declared as a conflict for following commands
         self.keys_clocks.add(dot, &cmd);
 
         // update command info


### PR DESCRIPTION
- the coordinator (in EPaxos & Atlas) was saving a command when handling the client submit, and then they would declare such command as a conflict when handling their own MCollect message; this was preventing fast paths with `f > 1`